### PR TITLE
fix LUT_CACHE is None error

### DIFF
--- a/imgaug/augmenters/color.py
+++ b/imgaug/augmenters/color.py
@@ -2485,6 +2485,10 @@ class AddToHueAndSaturation(meta.Augmenter):
         # image_hsv[..., 1] = cv2.LUT(image_hsv[..., 1], table_saturation)
 
         # code with using cache (at best maybe 10% faster for 64x64):
+        # if process is spawned cls._LUT_CACHE is None
+        if cls._LUT_CACHE is None:
+            cls._LUT_CACHE = cls._generate_lut_table()
+
         table_hue = cls._LUT_CACHE[0]
         table_saturation = cls._LUT_CACHE[1]
         tables = [


### PR DESCRIPTION
Here is the fix for the following error 
*/site-packages/imgaug/augmenters/color.py", line 2501, in _transform_image_cv2                                                                                        table_hue = cls._LUT_CACHE[0]                                                                           TypeError: 'NoneType' object is not subscriptable_

My environment use
```
import torch.multiprocessing as mp 
mp.set_start_method('spawn',force=True)
```